### PR TITLE
 Criar DeckService

### DIFF
--- a/src/app/services/deck.service.spec.ts
+++ b/src/app/services/deck.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DeckService } from './deck.service';
+
+describe('DeckService', () => {
+  let service: DeckService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DeckService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/deck.service.ts
+++ b/src/app/services/deck.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DeckService {
+  
+}

--- a/src/app/services/deck.service.ts
+++ b/src/app/services/deck.service.ts
@@ -16,5 +16,13 @@ export class DeckService {
      // Então ao fazer um collectionData(), traria tudo (nome, tipo...) menos id
   }
 
+  async pegarRandomDeck(): Promise<Deck> { 
+     // precisamos ESPERAR a lista com os decks chegarem para sortearmos um, por isso o await 
+     //Inclusive, ele não combina com o 'Observable', já que ele sempre vai estar atualizando e precisamos de um valor fixo
+     const decks = await firstValueFrom(this.pegarDecks());
+     const indice = Math.floor(Math.random() * decks.length);
+     const deckAleatorio = decks[indice];
+     return deckAleatorio;
+  }
   
 }

--- a/src/app/services/deck.service.ts
+++ b/src/app/services/deck.service.ts
@@ -1,8 +1,20 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
+import { Observable, firstValueFrom } from 'rxjs';
+import { collection, collectionData, Firestore } from '@angular/fire/firestore';
+import { Deck } from '../interfaces/deck'
 
 @Injectable({
   providedIn: 'root',
 })
 export class DeckService {
+  private firestore = inject(Firestore);
+
+  pegarDecks(): Observable<Deck[]>{
+     const decks = collection(this.firestore, 'decks' );
+     return collectionData(decks, { idField:'id' }) as Observable<Deck[]>;
+     // É necessário colocarmos o "idField" pois o firestore não traz ele automaticamente
+     // Então ao fazer um collectionData(), traria tudo (nome, tipo...) menos id
+  }
+
   
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,4 +1,5 @@
 /* To learn more about this file see: https://angular.io/config/tsconfig. */
+
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {


### PR DESCRIPTION
## Objetivo
Centralizar toda a lógica de acesso à coleção de decks Firestore, provendo métodos reutilizáveis para a Home e a Biblioteca.

Closes #44 