### PR TITLE
feat: Criar interface e o serviço 'Progress'

### DIFF
--- a/src/app/interfaces/progress.ts
+++ b/src/app/interfaces/progress.ts
@@ -1,4 +1,4 @@
-export interface DeckProgress {
+export interface Progress {
      id: string;
      deckId: string;
      totalCards: number;

--- a/src/app/interfaces/progressdeck.ts
+++ b/src/app/interfaces/progressdeck.ts
@@ -1,0 +1,7 @@
+export interface DeckProgress {
+     id: string;
+     deckId: string;
+     totalCards: number;
+     respondedCards: number;
+     correctCards: number;
+}

--- a/src/app/services/progress.service.spec.ts
+++ b/src/app/services/progress.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ProgressService } from './progress.service';
+
+describe('ProgressService', () => {
+  let service: ProgressService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ProgressService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/progress.service.ts
+++ b/src/app/services/progress.service.ts
@@ -1,8 +1,23 @@
-import { Injectable } from '@angular/core';
-
+import { Injectable, inject } from '@angular/core';
+import { doc, setDoc,docData, Firestore } from '@angular/fire/firestore';
+import { Observable } from 'rxjs';
+import { Progress } from '../interfaces/progress';
 @Injectable({
-  providedIn: 'root',
+     providedIn: 'root',
 })
 export class ProgressService {
-  
+     private firestore = inject(Firestore);
+
+     pegarProgresso(deckId: string, uid: string): Observable<Progress | undefined> {
+           const docProgresso = doc(this.firestore, 'users', uid, 'progress', deckId)
+          return docData(docProgresso) as Observable<Progress | undefined>;
+     }
+
+    async salvarProgresso(deckId: string, uid: string, deckInfo: Progress): Promise<void> {
+          const docProgresso = doc(this.firestore, 'users', uid, 'progress', deckId); 
+          await setDoc(docProgresso, deckInfo, {merge: false});
+          // o merge:false é porque o firestore tem a tendencia de mesclar os dados,
+          // fazendo que caso o objeto nao tenha algum campo, ele vai manter o valor antigo
+          // por isso não permitimos, assim, ele substitui totalmente
+     }
 }

--- a/src/app/services/progress.service.ts
+++ b/src/app/services/progress.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ProgressService {
+  
+}


### PR DESCRIPTION
## Objetivo
Criar progress.service.ts responsável por salvar e recuperar o DeckProgress de um usuário. O documento deve ser identificado de forma composta: users/{userId}/progress/{deckId}, garantindo isolamento por conta. O método de salvar deve usar set() com merge: false para sobrescrever completamente o progresso anterior.

Closes #50 