### PR TITLE
feat: Serviço de 'session' feito!

### DIFF
--- a/src/app/interfaces/session.ts
+++ b/src/app/interfaces/session.ts
@@ -1,0 +1,9 @@
+import { Card } from './card'
+
+export interface Session {
+     currentCard: number,
+     totalCards: number,
+     correctCards: Card[];
+     wrongCards: Card[];
+     skippedCards: Card[];
+}

--- a/src/app/interfaces/session.ts
+++ b/src/app/interfaces/session.ts
@@ -2,7 +2,7 @@ import { Card } from './card'
 
 export interface Session {
      currentCard: number,
-     totalCards: card[],
+     allCards: Card[],
      correctCards: Card[];
      wrongCards: Card[];
      skippedCards: Card[];

--- a/src/app/interfaces/session.ts
+++ b/src/app/interfaces/session.ts
@@ -2,7 +2,7 @@ import { Card } from './card'
 
 export interface Session {
      currentCard: number,
-     totalCards: number,
+     totalCards: card[],
      correctCards: Card[];
      wrongCards: Card[];
      skippedCards: Card[];

--- a/src/app/services/session.service.spec.ts
+++ b/src/app/services/session.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { SessionService } from './session.service';
+
+describe('SessionService', () => {
+  let service: SessionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(SessionService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class SessionService {
+  
+}

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -7,7 +7,7 @@ export class SessionService {
 
      private session: Session = { // inicializar o molde do 0
           currentCard: 0,
-          allCards: [], 
+          allCards: [],
           correctCards: [],
           wrongCards: [],
           skippedCards: []
@@ -47,12 +47,20 @@ export class SessionService {
           this.session.currentCard++ // para mudar o card e prosseguir para o próximo
      }
 
-     calcularProgresso() {
-         const progressoAtual = this.session.correctCards.length / this.session.allCards.length * 100;
-         return progressoAtual
+     avancarCard() {
+          this.session.currentCard++;
      }
 
-     finalizarSessao () {
+     voltarCard() {
+          this.session.currentCard--;
+     }
+
+     calcularProgresso() {
+          const progressoAtual = this.session.correctCards.length / this.session.allCards.length * 100;
+          return progressoAtual
+     }
+
+     finalizarSessao() {
           // precisa ser salvo em var, se não a função apaga antes de retornar
           const allCards = this.session.allCards.length;
           const correctCards = this.session.correctCards;
@@ -66,6 +74,6 @@ export class SessionService {
                correctCards,
                wrongCards,
                progresso
-          } 
+          }
      }
 }

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -1,8 +1,36 @@
 import { Injectable } from '@angular/core';
+import { Card } from '../interfaces/card';
+import { Session } from '../interfaces/session';
 
-@Injectable({
-  providedIn: 'root',
-})
+@Injectable({ providedIn: 'root' })
 export class SessionService {
-  
+
+     private session: Session = {
+          currentCard: 0,
+          totalCards: 0,
+          correctCards: [],
+          wrongCards: [],
+          skippedCards: []
+     };
+
+     iniciarSessao(cards: Card[]) {
+          this.resetarSessao();
+          this.session.currentCard = 0;
+          this.session.totalCards = cards.length;
+     }
+
+     resetarSessao() {
+          this.session = {
+               currentCard: 0,
+               totalCards: 0,
+               correctCards: [],
+               wrongCards: [],
+               skippedCards: []
+          }
+     }
+
+     pegarCardAtual() {
+          
+     }
+
 }

--- a/src/app/services/session.service.ts
+++ b/src/app/services/session.service.ts
@@ -5,9 +5,9 @@ import { Session } from '../interfaces/session';
 @Injectable({ providedIn: 'root' })
 export class SessionService {
 
-     private session: Session = {
+     private session: Session = { // inicializar o molde do 0
           currentCard: 0,
-          totalCards: 0,
+          allCards: [], 
           correctCards: [],
           wrongCards: [],
           skippedCards: []
@@ -15,14 +15,13 @@ export class SessionService {
 
      iniciarSessao(cards: Card[]) {
           this.resetarSessao();
-          this.session.currentCard = 0;
-          this.session.totalCards = cards.length;
+          this.session.allCards = cards;
      }
 
      resetarSessao() {
           this.session = {
                currentCard: 0,
-               totalCards: 0,
+               allCards: [],
                correctCards: [],
                wrongCards: [],
                skippedCards: []
@@ -30,7 +29,43 @@ export class SessionService {
      }
 
      pegarCardAtual() {
-          
+          const posicao = this.session.currentCard; //pega o index do card atual
+          return this.session.allCards[posicao]; // pega o card que possui o mesmo index pego acima
      }
 
+     responderCard(resposta: 'certo' | 'errado' | 'pulado') {
+          const cardAtual = this.pegarCardAtual();
+
+          if (resposta === 'certo') {
+               this.session.correctCards.push(cardAtual);
+          } else if (resposta === 'errado') {
+               this.session.wrongCards.push(cardAtual);
+          } else {
+               this.session.skippedCards.push(cardAtual)
+          }
+
+          this.session.currentCard++ // para mudar o card e prosseguir para o próximo
+     }
+
+     calcularProgresso() {
+         const progressoAtual = this.session.correctCards.length / this.session.allCards.length * 100;
+         return progressoAtual
+     }
+
+     finalizarSessao () {
+          // precisa ser salvo em var, se não a função apaga antes de retornar
+          const allCards = this.session.allCards.length;
+          const correctCards = this.session.correctCards;
+          const wrongCards = this.session.wrongCards;
+          const progresso = this.calcularProgresso();
+
+          this.resetarSessao();
+
+          return { // Está se referenciando as variaveis criadas NESTA função
+               allCards,
+               correctCards,
+               wrongCards,
+               progresso
+          } 
+     }
 }


### PR DESCRIPTION
## Criar o SessionService — gerenciar estado da sessão de estudo em memória

## 1. Objetivo
Encapsular todo o estado e a lógica de controle de uma sessão de flashcards (progresso, navegação entre cards, contagem de acertos/erros) sem persistência direta — apenas gerenciamento em memória durante a sessão ativa.

## 2. Descrição Técnica
Criar session.service.ts stateful, responsável por inicializar uma sessão com a lista de cards de um deck, controlar o índice do card atual, registrar o resultado de cada card (correto, errado ou pulado via botão) e calcular o resultado final. Ao finalizar, retornar o objeto DeckProgress para ser salvo pelo ProgressService. O service deve ser resetável para suportar múltiplas sessões consecutivas.

Closes #51 